### PR TITLE
feat: remove the need to call loadPackages()

### DIFF
--- a/packages/lifelike_characters_service/CHANGELOG.md
+++ b/packages/lifelike_characters_service/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## 1.0.1
+
+- Fixed sapling warning about no `ServiceName` on the exported service ([#31])
+
+[#31]: https://github.com/Its-a-bit-random/Sapling/pull/31
+
 ## 1.0.0
 
 - Initial release

--- a/packages/lifelike_characters_service/pesde.lock
+++ b/packages/lifelike_characters_service/pesde.lock
@@ -2,5 +2,5 @@
 # It is not intended for manual editing.
 format = 2
 name = "sapling/lifelike_characters_service"
-version = "1.0.0"
+version = "1.0.1"
 target = "roblox"

--- a/packages/lifelike_characters_service/pesde.toml
+++ b/packages/lifelike_characters_service/pesde.toml
@@ -1,5 +1,5 @@
 name = "sapling/lifelike_characters_service"
-version = "1.0.0"
+version = "1.0.1"
 license = "MIT"
 repository = "https://github.com/Its-a-bit-random/Sapling"
 authors = [ "Sebastian S <gramps@itsabitrandom.com>" ]

--- a/packages/lifelike_characters_service/source/init.luau
+++ b/packages/lifelike_characters_service/source/init.luau
@@ -14,7 +14,7 @@ local LifelikeCharactersServiceServer = require(script.LifelikeCharactersService
 	- Seeing your body in first person
 	- Head following camera angle in first & third person.
 ]=]
-local LifelikeCharactersService = {}
+local LifelikeCharactersService = { ServiceName = "LifelikeCharactersService" }
 
 --[=[
 	@return LifelikeCharactersServiceClient

--- a/packages/sapling/CHANGELOG.md
+++ b/packages/sapling/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## 1.1.0
+
+- Packages are found automatically rather than having to call `Sapling.loadPackages` (function will be removed in the next Major update) ([#31])
+
+[#31]: https://github.com/Its-a-bit-random/Sapling/pull/31
+
 ## 1.0.0
 
 - Initial release

--- a/packages/sapling/pesde.lock
+++ b/packages/sapling/pesde.lock
@@ -2,7 +2,7 @@
 # It is not intended for manual editing.
 format = 2
 name = "sapling/sapling"
-version = "1.0.0"
+version = "1.1.0"
 target = "roblox"
 
 [graph."0x5eal/unzip@0.2.0 luau".pkg_ref]

--- a/packages/sapling/pesde.toml
+++ b/packages/sapling/pesde.toml
@@ -1,5 +1,5 @@
 name = "sapling/sapling"
-version = "1.0.0"
+version = "1.1.0"
 license = "MIT"
 repository = "https://github.com/Its-a-bit-random/Sapling"
 authors = [ "Sebastian S <gramps@itsabitrandom.com>" ]

--- a/packages/sapling/source/init.luau
+++ b/packages/sapling/source/init.luau
@@ -25,6 +25,44 @@ local havePackagesBeenStarted = false
 ]=]
 local Sapling = {}
 
+local function loadSaplingPackages()
+    local packagesFolder = nil :: Folder
+    do
+        local parent = script
+        while parent and parent:FindFirstChild(".pesde") == nil do
+            parent = parent.Parent
+        end
+        if parent == nil then
+            warn([[
+                [SAPLING] Cannot locate packages folder
+                    Sapling could not find the packages folder. Currently this only works if sapling is installed
+                    with the PESDE package manager. If you encouter this error please submit a bug report at
+                        https://github.com/Its-a-bit-random/Sapling/issues/new/choose
+            ]])
+            return
+        end
+        packagesFolder = parent
+    end
+
+    local instances = packagesFolder:GetChildren()
+    local modules = filterArray(instances, instanceOf("ModuleScript")) :: { ModuleScript }
+
+    _G.Sapling = Packages.getGlobalAPI()
+    for _, v in modules do
+        -- We use safe require here and discard any errors because some modules may
+        -- have some asserts about being on the server/client.
+        safeRequire(v)
+    end
+    _G.Sapling = nil
+
+    local packageModules = Packages.getModules()
+    for _, v in packageModules do
+        Sapling.loadService(v)
+    end
+
+    Packages.callLifecycles()
+end
+
 --[=[
 	Load a single service from a module
 ]=]
@@ -52,6 +90,10 @@ end
 	Loads all module scripts under `parent` ignoring anything which isn't a [ModuleScript] instance.
 ]=]
 function Sapling.loadServices(parent: Instance, recursive: boolean?)
+    if not havePackagesBeenStarted then
+        loadSaplingPackages()
+    end
+
     local instances = if recursive then parent:GetDescendants() else parent:GetChildren()
     local modules = filterArray(instances, instanceOf("ModuleScript")) :: { ModuleScript }
 
@@ -61,42 +103,10 @@ function Sapling.loadServices(parent: Instance, recursive: boolean?)
 end
 
 --[=[
-	This function only needs to be called if you are using any other Sapling Framework packages,
-	simply point it to your Packages folder and Sapling will handle the rest.
-
-	If you do not call this function at the right time, or at all, pacakges will throw an error and tell you that
-	you have not called this function.
-
-	:::warning
-	This function **NEEDS** to be called before you call `loadServices` otherwise packages will error.
-	:::
-
-	:::danger
-	If you use [Actor] you will need to call this in every [Actor] to avoid errors.
-	:::
-
-	@error "You can only call loadPackages one time" -- You should only call this function once, before you call `loadService`.
+	@deprecated v1.1.0 -- Function is obsolete and will be removed in the next MAJOR version.
 ]=]
-function Sapling.loadPackages(packagesFolder: Folder)
-    assert(not havePackagesBeenStarted, "You can only call loadPackages one time")
-
-    local instances = packagesFolder:GetChildren()
-    local modules = filterArray(instances, instanceOf("ModuleScript")) :: { ModuleScript }
-
-    _G.Sapling = Packages.getGlobalAPI()
-    for _, v in modules do
-        -- We use safe require here and discard any errors because some modules may
-        -- have some asserts about being on the server/client.
-        safeRequire(v)
-    end
-    _G.Sapling = nil
-
-    local packageModules = Packages.getModules()
-    for _, v in packageModules do
-        Sapling.loadService(v)
-    end
-
-    Packages.callLifecycles()
+function Sapling.loadPackages(_p: any)
+    warn(`Sapling.loadPackages() has been deprecated in 1.1.0 and no longer needs to be called`)
 end
 
 --[=[

--- a/packages/sapling/source/init.luau
+++ b/packages/sapling/source/init.luau
@@ -26,8 +26,8 @@ local havePackagesBeenStarted = false
 local Sapling = {}
 
 local function loadSaplingPackages()
-    local packagesFolder = nil :: Folder
-    do
+    local packagesFolder = (_G.SAPLING_PACKAGES_FOLDER or nil) :: Folder
+    if packagesFolder == nil then
         local parent = script
         while parent and parent:FindFirstChild(".pesde") == nil do
             parent = parent.Parent
@@ -36,8 +36,12 @@ local function loadSaplingPackages()
             warn([[
                 [SAPLING] Cannot locate packages folder
                     Sapling could not find the packages folder. Currently this only works if sapling is installed
-                    with the PESDE package manager. If you encouter this error please submit a bug report at
+                    with the PESDE package manager. If you encouter this error please submit a bug report at:
                         https://github.com/Its-a-bit-random/Sapling/issues/new/choose
+
+                    You can also manually set the packages folder using:
+                        _G.SAPLING_PACKAGES_FOLDER = <Packages>
+                    Before you call .loadServices()
             ]])
             return
         end

--- a/source/server/runtime.server.luau
+++ b/source/server/runtime.server.luau
@@ -1,14 +1,8 @@
-local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local BlockingDispatcher = require(script.Parent.BlockingDispatcher)
 local binder = require(script.Parent.Parent.Parent.ReplicatedStorage.packages.binder.binder)
-local instanceUtils = require(script.Parent.Parent.Parent.ReplicatedStorage.packages.instanceUtils.instanceUtils)
 local queryBuilder = require(script.Parent.Parent.Parent.ReplicatedStorage.packages.queryBuilder)
 local sapling = require(script.Parent.Parent.Parent.ReplicatedStorage.packages.sapling)
 
-local part = instanceUtils.WaitForChildWhichIsA(workspace, "Humanoid")
-print(part)
-
-sapling.loadPackages(ReplicatedStorage.packages)
 sapling.loadServices(script.Parent.services)
 sapling.fireLifecycle("onStart")
 
@@ -22,14 +16,14 @@ local RainbowEffect = {}
 RainbowEffect.__index = RainbowEffect
 
 function RainbowEffect.new(instance: Part)
-	local self = setmetatable({}, RainbowEffect)
-	self.p = instance
-	self.p.Color = Color3.fromRGB(255, 255, 0)
-	return self
+    local self = setmetatable({}, RainbowEffect)
+    self.p = instance
+    self.p.Color = Color3.fromRGB(255, 255, 0)
+    return self
 end
 
 function RainbowEffect.Destroy(self)
-	self.p.Color = Color3.fromRGB(255, 0, 0)
+    self.p.Color = Color3.fromRGB(255, 0, 0)
 end
 
 local coolBinder = binder.new("Rainbow", RainbowEffect)


### PR DESCRIPTION
Closes #27 

Moved load packages to be called within sapling itself automatically without the need for the user to call it passing a packages folder. We find the packages folder automatically by looking up the tree until we find a folder which has a `.pesde` folder inside of it.